### PR TITLE
Minor: import JASP into QML

### DIFF
--- a/inst/qml/Power.qml
+++ b/inst/qml/Power.qml
@@ -17,6 +17,7 @@
 //
 import QtQuick			2.8
 import QtQuick.Layouts	1.3
+import JASP
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 


### PR DESCRIPTION
Otherwise we'd get the annoying `Power.qml:103: ReferenceError: JASP is not defined` messages for  `inclusive: JASP.None`
`