### PR TITLE
Output error messages when computing values during plot generation

### DIFF
--- a/R/commonPower.R
+++ b/R/commonPower.R
@@ -705,3 +705,12 @@
     alternative = alternative, method = METHOD
   ), class = "power.htest"))
 }
+
+.errorMessageUnsolvable <- function (errorObject) {
+  return(paste(
+    gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"),
+    gettext("Error Message:"),
+    errorObject,
+    sep = "\n"
+  ))
+}

--- a/R/pwr_1p.R
+++ b/R/pwr_1p.R
@@ -599,7 +599,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -633,7 +633,7 @@
     .pwrPTest(n = nn, p0 = p0, p = p, sig.level = alpha, alternative = alt)$power
   }))
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -641,7 +641,7 @@
     abs(2 * (asin(sqrt(.pwrPTest(n = N, p0 = p0, sig.level = alpha, power = power, alternative = alt)$p)) - asin(sqrt(p0))))
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -719,7 +719,7 @@
 
   y <- try(.pwrPTest(n = n, p0 = p0, p = pp, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   if (power < 0.999) {
@@ -798,7 +798,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n >= maxn && n >= ps$maxn) {
     maxn <- ceiling(n * ps$max.scale)
@@ -815,7 +815,7 @@
 
   y <- try(.pwrPTest(n = nn, p0 = p0, p = p1, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_1var.R
+++ b/R/pwr_1var.R
@@ -611,7 +611,7 @@
     rho = d, power = max(0.99, power), sig.level = alpha, alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -644,16 +644,18 @@
   z.pwr <- try(sapply(dd, function(delta) {
     .pwrVarTest(n = nn, rho = delta, sig.level = alpha, alternative = alt)$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
   z.delta <- try(sapply(nn, function(N) {
     .pwrVarTest(n = N, sig.level = alpha, power = power, alternative = alt)$rho
   }))
-  if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+
+  if (jaspBase::isTryError(z.delta)) {
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -734,7 +736,7 @@
 
   y <- try(.pwrVarTest(n = n, rho = dd, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -790,7 +792,7 @@
   )$n))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n >= maxn && n >= ps$maxn) {
     maxn <- ceiling(n * ps$max.scale)
@@ -808,7 +810,7 @@
 
   y <- try(.pwrVarTest(n = nn, rho = d, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_2p.R
+++ b/R/pwr_2p.R
@@ -383,7 +383,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -421,8 +421,9 @@
       alternative = alt
     )$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -434,7 +435,7 @@
     )$p1)) - asin(sqrt(p0))))
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -537,7 +538,7 @@
 
   y <- try(.pwr2P2NTest(n = n1, n.ratio = n_ratio, p0 = p0, p1 = pp, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   if (power < 0.999) {
@@ -684,7 +685,7 @@
   )$n))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n1 >= maxn && n1 >= ps$maxn) {
     maxn <- ceiling(n1 * ps$max.scale)
@@ -705,7 +706,7 @@
     p0 = p0, p1 = p1, sig.level = alpha, alternative = alt
   )$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_2var.R
+++ b/R/pwr_2var.R
@@ -387,7 +387,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -426,8 +426,9 @@
       alternative = alt
     )$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -441,7 +442,7 @@
     )$rho
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -548,7 +549,7 @@
 
   y <- try(.pwr2Var2NTest(n = n1, n.ratio = n_ratio, rho = dd, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -696,7 +697,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n1 >= maxn && n1 >= ps$maxn) {
     maxn <- ceiling(n1 * ps$max.scale)
@@ -718,7 +719,7 @@
     rho = d, sig.level = alpha, alternative = alt
   )$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_ttestis.R
+++ b/R/pwr_ttestis.R
@@ -359,7 +359,7 @@
     alternative = alt
   ))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -393,8 +393,9 @@
       alternative = alt
     )$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -408,7 +409,7 @@
     )$d
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -500,7 +501,7 @@
 
   y <- try(.pwrT2NTest(n1 = n1, n2 = n2, d = dd, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -623,7 +624,7 @@
   ))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n1 >= maxn && n1 >= ps$maxn) {
     maxn <- ceiling(n1 * ps$max.scale)
@@ -642,7 +643,7 @@
     d = d, sig.level = alpha, alternative = alt
   )$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_ttestos.R
+++ b/R/pwr_ttestos.R
@@ -543,7 +543,7 @@
     type = "one.sample"
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -568,7 +568,7 @@
     pwr::pwr.t.test(n = nn, d = delta, sig.level = alpha, alternative = alt, type = "one.sample")$power
   }))
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -576,7 +576,7 @@
     pwr::pwr.t.test(n = N, sig.level = alpha, power = power, alternative = alt, type = "one.sample")$d
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -641,7 +641,7 @@
 
   y <- try(pwr::pwr.t.test(n = n, d = dd, sig.level = alpha, alternative = alt, type = "one.sample")$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -698,7 +698,7 @@
   )$n))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n >= maxn && n >= ps$maxn) {
     maxn <- ceiling(n * ps$max.scale)
@@ -710,7 +710,7 @@
 
   y <- try(pwr::pwr.t.test(n = nn, d = d, sig.level = alpha, alternative = alt, type = "one.sample")$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_ttestps.R
+++ b/R/pwr_ttestps.R
@@ -543,7 +543,7 @@
     type = "paired"
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -567,8 +567,9 @@
   z.pwr <- try(sapply(dd, function(delta) {
     pwr::pwr.t.test(n = nn, d = delta, sig.level = alpha, alternative = alt, type = "paired")$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -576,7 +577,7 @@
     pwr::pwr.t.test(n = N, sig.level = alpha, power = power, alternative = alt, type = "paired")$d
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -641,7 +642,7 @@
 
   y <- try(pwr::pwr.t.test(n = n, d = dd, sig.level = alpha, alternative = alt, type = "paired")$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -698,7 +699,7 @@
   )$n))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n >= maxn && n >= ps$maxn) {
     maxn <- ceiling(n * ps$max.scale)
@@ -710,7 +711,7 @@
 
   y <- try(pwr::pwr.t.test(n = nn, d = d, sig.level = alpha, alternative = alt, type = "paired")$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 

--- a/R/pwr_z.R
+++ b/R/pwr_z.R
@@ -540,7 +540,7 @@
     alternative = alt
   )$n))
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   }
 
@@ -564,8 +564,9 @@
   z.pwr <- try(sapply(dd, function(delta) {
     pwr::pwr.norm.test(n = nn, d = delta, sig.level = alpha, alternative = alt)$power
   }))
+
   if (jaspBase::isTryError(z.pwr)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.pwr))
     return()
   }
 
@@ -573,7 +574,7 @@
     pwr::pwr.norm.test(n = N, sig.level = alpha, power = power, alternative = alt)$d
   }))
   if (jaspBase::isTryError(z.delta)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the Power Contour plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(z.delta))
     return()
   }
 
@@ -637,7 +638,7 @@
 
   y <- try(pwr::pwr.norm.test(n = n, d = dd, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the power curve. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
   cols <- ps$pal(ps$pow.n.levels)
@@ -692,7 +693,7 @@
   )$n))
 
   if (jaspBase::isTryError(maxn)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(maxn))
     return()
   } else if (n >= maxn && n >= ps$maxn) {
     maxn <- ceiling(n * ps$max.scale)
@@ -704,7 +705,7 @@
 
   y <- try(pwr::pwr.norm.test(n = nn, d = d, sig.level = alpha, alternative = alt)$power)
   if (jaspBase::isTryError(y)) {
-    image$setError(gettext("The specified design leads to (an) unsolvable equation(s) while constructing the 'Power Curve by N' plot. Try to enter less extreme values for the parameters"))
+    image$setError(.errorMessageUnsolvable(y))
     return()
   }
 


### PR DESCRIPTION
When the creation of a plot fails there's currently only a very generic error message in the plot (which may actually be wrong, if it's due to an actual bug and not just a misconfiguration).

This PR appends the original error message to allow for easier debugging and understanding of errors.